### PR TITLE
article css refine

### DIFF
--- a/src/css/article.css
+++ b/src/css/article.css
@@ -1,12 +1,3 @@
-.section {
-}
-
-.article {
-}
-
-.container {
-}
-
 .article-text {
   margin-bottom: 32px;
 }
@@ -38,7 +29,7 @@
 
 /* desktop */
 @media screen and (min-width: 1440px) {
-  .container {
+  .article .container {
     display: flex;
     gap: 32px;
   }

--- a/src/css/article.css
+++ b/src/css/article.css
@@ -1,5 +1,7 @@
-.article-text {
-  margin-bottom: 32px;
+.article-container {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
 .article-text-title {
@@ -29,9 +31,8 @@
 
 /* desktop */
 @media screen and (min-width: 1440px) {
-  .article .container {
-    display: flex;
-    gap: 32px;
+  .article-container {
+    flex-direction: row;
   }
 
   .article-text {

--- a/src/partials/article.html
+++ b/src/partials/article.html
@@ -1,5 +1,5 @@
-<section class="section article" id="article">
-  <div class="container">
+<section class="section" id="article">
+  <div class="container article-container">
     <div class="article-text">
       <h2 class="article-text-title">
         Welcome to Booksy – your cozy corner for handpicked reads.


### PR DESCRIPTION
Empty rules cleared.
The direct container selector replaced with a more specific scoped selector (.article .container instead of just .container).